### PR TITLE
allow custom reading file handling

### DIFF
--- a/tests/test_custom_file_handle.py
+++ b/tests/test_custom_file_handle.py
@@ -1,0 +1,37 @@
+import functools
+import os
+
+import h5py
+import numpy.testing as npt
+
+import znh5md
+
+
+def test_AtomsReader(tmp_path, atoms_list):
+    os.chdir(tmp_path)
+    print(tmp_path)
+
+    db = znh5md.io.DataWriter(filename="db.h5")
+    db.initialize_database_groups()
+
+    reader = znh5md.io.AtomsReader(atoms_list, frames_per_chunk=10)
+    db.add(reader)
+
+    def file_handle(filename):
+        file = open(filename, "rb")
+        return h5py.File(file)
+
+    data = znh5md.ASEH5MD(
+        "db.h5",
+        format_handler=functools.partial(znh5md.FormatHandler, file_handle=file_handle),
+    )
+
+    atoms = data.get_atoms_list()
+
+    assert len(atoms) == len(atoms_list)
+    for a, b in zip(atoms, atoms_list):
+        npt.assert_array_equal(a.get_positions(), b.get_positions())
+        npt.assert_array_equal(a.get_atomic_numbers(), b.get_atomic_numbers())
+        npt.assert_array_equal(a.get_forces(), b.get_forces())
+        npt.assert_array_equal(a.get_cell(), b.get_cell())
+        npt.assert_array_equal(a.get_potential_energy(), b.get_potential_energy())

--- a/znh5md/__init__.py
+++ b/znh5md/__init__.py
@@ -2,9 +2,9 @@
 import importlib.metadata
 
 from znh5md import io
-from znh5md.znh5md import ASEH5MD, DaskH5MD
+from znh5md.znh5md import ASEH5MD, DaskH5MD, FormatHandler
 
-__all__ = ["DaskH5MD", "ASEH5MD", "io"]
+__all__ = ["DaskH5MD", "ASEH5MD", "io", "FormatHandler"]
 
 
 __version__ = importlib.metadata.version("znh5md")

--- a/znh5md/format/__init__.py
+++ b/znh5md/format/__init__.py
@@ -9,6 +9,8 @@ import h5py
 class FormatHandler:
     filename: str
 
+    file_handle: typing.Callable = h5py.File
+
     def __post_init__(self):
         self.particle_key = None
         with self.file as file:
@@ -22,7 +24,7 @@ class FormatHandler:
     @property
     def file(self) -> h5py.File:
         """The 'h5py.File' from filename."""
-        return h5py.File(self.filename)
+        return self.file_handle(self.filename)
 
     @property
     def time_dependent_groups(self) -> typing.List[str]:


### PR DESCRIPTION
For DVCFileSystem we need to allow for custom `with open` BytesIO reading. This is now possible:

```python
def file_handle(filename):
        file = open(filename, "rb")
        return h5py.File(file)

    data = znh5md.ASEH5MD(
        "db.h5",
        format_handler=functools.partial(znh5md.FormatHandler, file_handle=file_handle),
    )
```

I don't think that this will be used very often, so the API is a little bit clunky.