### PR TITLE
Add `pbc` group in addition to `boundary`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ You can use ZnH5MD to store ASE Atoms objects in the H5MD format.
 
 > The ASEH5MD interface will not provide any time and step information.
 
+> If you have a list of Atoms with different PBC values, you can use `znh5md.io.AtomsReader(atoms, use_pbc_group=True)`. This will create a `pbc` group in `box/` that also contains `step` and `time`. This is not an official H5MD specification so it can cause issues with other tools. If you don't specify this, the pbc of the first atoms in the list will be applied.
+
 ```python
 import znh5md
 import ase

--- a/poetry.lock
+++ b/poetry.lock
@@ -836,19 +836,19 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "filelock"
-version = "3.10.4"
+version = "3.10.7"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "filelock-3.10.4-py3-none-any.whl", hash = "sha256:6d332dc5c896f18ba93a21d987155e97c434a96d3fe4042ca70d0b3b46e3b470"},
-    {file = "filelock-3.10.4.tar.gz", hash = "sha256:9fc1734dbddcdcd4aaa02c160dd94db5272b92dfa859b44ec8df28e160b751f0"},
+    {file = "filelock-3.10.7-py3-none-any.whl", hash = "sha256:bde48477b15fde2c7e5a0713cbe72721cb5a5ad32ee0b8f419907960b9d75536"},
+    {file = "filelock-3.10.7.tar.gz", hash = "sha256:892be14aa8efc01673b5ed6589dbccb95f9a8596f0507e232626155495c18105"},
 ]
 
 [package.extras]
 docs = ["furo (>=2022.12.7)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.2.2)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.2)", "diff-cover (>=7.5)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "fonttools"
@@ -2201,19 +2201,19 @@ tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "pa
 
 [[package]]
 name = "platformdirs"
-version = "3.1.1"
+version = "3.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.1.1-py3-none-any.whl", hash = "sha256:e5986afb596e4bb5bde29a79ac9061aa955b94fca2399b7aaac4090860920dd8"},
-    {file = "platformdirs-3.1.1.tar.gz", hash = "sha256:024996549ee88ec1a9aa99ff7f8fc819bb59e2c3477b410d90a16d32d6e707aa"},
+    {file = "platformdirs-3.2.0-py3-none-any.whl", hash = "sha256:ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e"},
+    {file = "platformdirs-3.2.0.tar.gz", hash = "sha256:d5b638ca397f25f979350ff789db335903d7ea010ab28903f57b27e1b16c2b08"},
 ]
 
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -2466,26 +2466,26 @@ files = [
 
 [[package]]
 name = "pywin32"
-version = "305"
+version = "306"
 description = "Python for Window Extensions"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pywin32-305-cp310-cp310-win32.whl", hash = "sha256:421f6cd86e84bbb696d54563c48014b12a23ef95a14e0bdba526be756d89f116"},
-    {file = "pywin32-305-cp310-cp310-win_amd64.whl", hash = "sha256:73e819c6bed89f44ff1d690498c0a811948f73777e5f97c494c152b850fad478"},
-    {file = "pywin32-305-cp310-cp310-win_arm64.whl", hash = "sha256:742eb905ce2187133a29365b428e6c3b9001d79accdc30aa8969afba1d8470f4"},
-    {file = "pywin32-305-cp311-cp311-win32.whl", hash = "sha256:19ca459cd2e66c0e2cc9a09d589f71d827f26d47fe4a9d09175f6aa0256b51c2"},
-    {file = "pywin32-305-cp311-cp311-win_amd64.whl", hash = "sha256:326f42ab4cfff56e77e3e595aeaf6c216712bbdd91e464d167c6434b28d65990"},
-    {file = "pywin32-305-cp311-cp311-win_arm64.whl", hash = "sha256:4ecd404b2c6eceaca52f8b2e3e91b2187850a1ad3f8b746d0796a98b4cea04db"},
-    {file = "pywin32-305-cp36-cp36m-win32.whl", hash = "sha256:48d8b1659284f3c17b68587af047d110d8c44837736b8932c034091683e05863"},
-    {file = "pywin32-305-cp36-cp36m-win_amd64.whl", hash = "sha256:13362cc5aa93c2beaf489c9c9017c793722aeb56d3e5166dadd5ef82da021fe1"},
-    {file = "pywin32-305-cp37-cp37m-win32.whl", hash = "sha256:a55db448124d1c1484df22fa8bbcbc45c64da5e6eae74ab095b9ea62e6d00496"},
-    {file = "pywin32-305-cp37-cp37m-win_amd64.whl", hash = "sha256:109f98980bfb27e78f4df8a51a8198e10b0f347257d1e265bb1a32993d0c973d"},
-    {file = "pywin32-305-cp38-cp38-win32.whl", hash = "sha256:9dd98384da775afa009bc04863426cb30596fd78c6f8e4e2e5bbf4edf8029504"},
-    {file = "pywin32-305-cp38-cp38-win_amd64.whl", hash = "sha256:56d7a9c6e1a6835f521788f53b5af7912090674bb84ef5611663ee1595860fc7"},
-    {file = "pywin32-305-cp39-cp39-win32.whl", hash = "sha256:9d968c677ac4d5cbdaa62fd3014ab241718e619d8e36ef8e11fb930515a1e918"},
-    {file = "pywin32-305-cp39-cp39-win_amd64.whl", hash = "sha256:50768c6b7c3f0b38b7fb14dd4104da93ebced5f1a50dc0e834594bff6fbe1271"},
+    {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
+    {file = "pywin32-306-cp310-cp310-win_amd64.whl", hash = "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8"},
+    {file = "pywin32-306-cp311-cp311-win32.whl", hash = "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407"},
+    {file = "pywin32-306-cp311-cp311-win_amd64.whl", hash = "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e"},
+    {file = "pywin32-306-cp311-cp311-win_arm64.whl", hash = "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a"},
+    {file = "pywin32-306-cp312-cp312-win32.whl", hash = "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b"},
+    {file = "pywin32-306-cp312-cp312-win_amd64.whl", hash = "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e"},
+    {file = "pywin32-306-cp312-cp312-win_arm64.whl", hash = "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040"},
+    {file = "pywin32-306-cp37-cp37m-win32.whl", hash = "sha256:1c73ea9a0d2283d889001998059f5eaaba3b6238f767c9cf2833b13e6a685f65"},
+    {file = "pywin32-306-cp37-cp37m-win_amd64.whl", hash = "sha256:72c5f621542d7bdd4fdb716227be0dd3f8565c11b280be6315b06ace35487d36"},
+    {file = "pywin32-306-cp38-cp38-win32.whl", hash = "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a"},
+    {file = "pywin32-306-cp38-cp38-win_amd64.whl", hash = "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"},
+    {file = "pywin32-306-cp39-cp39-win32.whl", hash = "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802"},
+    {file = "pywin32-306-cp39-cp39-win_amd64.whl", hash = "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4"},
 ]
 
 [[package]]
@@ -3050,15 +3050,19 @@ files = [
 
 [[package]]
 name = "webcolors"
-version = "1.12"
-description = "A library for working with color names and color values formats defined by HTML and CSS."
+version = "1.13"
+description = "A library for working with the color formats defined by HTML and CSS."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "webcolors-1.12-py3-none-any.whl", hash = "sha256:d98743d81d498a2d3eaf165196e65481f0d2ea85281463d856b1e51b09f62dce"},
-    {file = "webcolors-1.12.tar.gz", hash = "sha256:16d043d3a08fd6a1b1b7e3e9e62640d09790dce80d2bdd4792a175b35fe794a9"},
+    {file = "webcolors-1.13-py3-none-any.whl", hash = "sha256:29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"},
+    {file = "webcolors-1.13.tar.gz", hash = "sha256:c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"},
 ]
+
+[package.extras]
+docs = ["furo", "sphinx", "sphinx-copybutton", "sphinx-inline-tabs", "sphinx-notfound-page", "sphinxext-opengraph"]
+tests = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "webencodings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "znh5md"
-version = "0.1.3"
+version = "0.1.4"
 description = "High Performance Interface for H5MD Trajectories"
 authors = ["zincwarecode <zincwarecode@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,9 +73,11 @@ def atoms_list(request) -> list[ase.Atoms]:
             for _ in range(21)
         ]
     # create some variations in PBC
-    atoms[0].pbc = np.array([True, True, False])
-    atoms[1].pbc = np.array([True, False, True])
-    atoms[2].pbc = False
+    # atoms[0].pbc = np.array([True, True, False])
+    # atoms[1].pbc = np.array([True, False, True])
+    # atoms[2].pbc = False
+    for atom in atoms:
+        atom.pbc = True
 
     for idx, atom in enumerate(atoms):
         stress = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,9 @@ def atoms_list(request) -> list[ase.Atoms]:
         - None: use default values
         - "vary_size": use ase.collections.g2
         - "no_stress": do not set stress
+        - "vary_size_vary_pbc": use ase.collections.g2 and vary pbc
     """
-    if getattr(request, "param", None) == "vary_size":
+    if getattr(request, "param", "").startswith("vary_size"):
         atoms = [ase.build.molecule(x) for x in ase.collections.g2.names]
     else:
         random.seed(1234)
@@ -72,12 +73,10 @@ def atoms_list(request) -> list[ase.Atoms]:
             )
             for _ in range(21)
         ]
-    # TODO create some variations in PBC
-    # atoms[0].pbc = np.array([True, True, False])
-    # atoms[1].pbc = np.array([True, False, True])
-    # atoms[2].pbc = False
-    for atom in atoms:
-        atom.pbc = True
+    if getattr(request, "param", "").endswith("vary_pbc"):
+        atoms[0].pbc = np.array([True, True, False])
+        atoms[1].pbc = np.array([True, False, True])
+        atoms[2].pbc = False
 
     for idx, atom in enumerate(atoms):
         stress = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def atoms_list(request) -> list[ase.Atoms]:
             )
             for _ in range(21)
         ]
-    # create some variations in PBC
+    # TODO create some variations in PBC
     # atoms[0].pbc = np.array([True, True, False])
     # atoms[1].pbc = np.array([True, False, True])
     # atoms[2].pbc = False

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -62,3 +62,53 @@ def test_AtomsReader(tmp_path, reader, atoms_list, use_add):
         npt.assert_array_equal(
             znh5md.utils.rm_nan(species[idx]), atoms.get_atomic_numbers()
         )
+
+
+@pytest.mark.parametrize("reader", [znh5md.io.ASEFileReader, znh5md.io.AtomsReader])
+@pytest.mark.parametrize("atoms_list", ["vary_size", "vary_pbc_vary_pbc"], indirect=True)
+def test_AtomsReader_with_pbc_group(tmp_path, reader, atoms_list):
+    os.chdir(tmp_path)
+    print(tmp_path)
+
+    db = znh5md.io.DataWriter(filename="db.h5")
+    db.initialize_database_groups()
+
+    if reader == znh5md.io.AtomsReader:
+        inputs = atoms_list
+    elif reader == znh5md.io.ASEFileReader:
+        inputs = "traj.xyz"
+        ase.io.write(inputs, atoms_list)
+
+    reader = reader(inputs, frames_per_chunk=3, step=1, time=0.1, use_pbc_group=True)
+
+    # we use a really small frames_per_chunk for testing purposes
+    db.add(reader)
+
+    data = znh5md.ASEH5MD("db.h5")
+    atoms = data.get_atoms_list()
+
+    assert len(atoms) == len(atoms_list)
+    for a, b in zip(atoms, atoms_list):
+        npt.assert_array_almost_equal(a.get_positions(), b.get_positions())
+        npt.assert_array_equal(a.get_atomic_numbers(), b.get_atomic_numbers())
+        npt.assert_array_almost_equal(a.get_forces(), b.get_forces())
+        npt.assert_array_almost_equal(a.get_cell(), b.get_cell())
+        npt.assert_array_almost_equal(a.get_potential_energy(), b.get_potential_energy())
+        npt.assert_array_equal(a.get_pbc(), b.get_pbc())
+        npt.assert_array_almost_equal(a.get_stress(), b.get_stress())
+
+    # now test with Dask
+    traj = znh5md.DaskH5MD("db.h5")
+    positions = traj.position.value.compute()
+    time = traj.position.time.compute()
+    step = traj.position.step.compute()
+    species = traj.position.species.compute()
+    for idx, atoms in enumerate(atoms_list):
+        npt.assert_array_almost_equal(
+            znh5md.utils.rm_nan(positions[idx]), atoms.get_positions()
+        )
+        npt.assert_array_almost_equal(time[idx], idx / 10)
+        npt.assert_array_equal(step[idx], idx)
+        npt.assert_array_equal(
+            znh5md.utils.rm_nan(species[idx]), atoms.get_atomic_numbers()
+        )

--- a/tests/test_znh5md.py
+++ b/tests/test_znh5md.py
@@ -5,7 +5,7 @@ import znh5md
 
 
 def test_version():
-    assert znh5md.__version__ == "0.1.3"
+    assert znh5md.__version__ == "0.1.4"
 
 
 def test_shape(example_h5):

--- a/znh5md/format/__init__.py
+++ b/znh5md/format/__init__.py
@@ -7,7 +7,15 @@ import h5py
 
 @dataclasses.dataclass
 class GRP:
-    """Group names for h5md files."""
+    """Group names for h5md files.
+
+    Attributes
+    ----------
+    pbc:
+        This group is not a H5MD group that supports time-dependent pbc.
+        It can be used to store data from different trajectories in one group,
+        that don't share pbc.
+    """
 
     edges: str = "edges"
     boundary: str = "boundary"
@@ -17,6 +25,7 @@ class GRP:
     forces: str = "forces"
     stress: str = "stress"
     velocity: str = "velocity"
+    pbc: str = "pbc"
 
 
 @dataclasses.dataclass
@@ -68,4 +77,9 @@ class FormatHandler:
     @property
     def boundary(self):
         group = f"particles/{self.particle_key}/box/{GRP.boundary}"
+        return self.file[group]
+
+    @property
+    def pbc(self):
+        group = f"particles/{self.particle_key}/box/{GRP.pbc}"
         return self.file[group]

--- a/znh5md/format/__init__.py
+++ b/znh5md/format/__init__.py
@@ -29,15 +29,11 @@ class GRP:
     pbc: str = "pbc"
 
     @staticmethod
-    def encode_pbc(value) -> np.ndarray:
-        if value is None:  # TODO is this really required?
-            return None
+    def encode_boundary(value) -> np.ndarray:
         return np.array(["periodic".encode() if x else "none".encode() for x in value])
 
     @staticmethod
-    def decode_pbc(value) -> np.ndarray:  # TODO rename decode_boundary
-        if value is None:  # TODO is this really required?
-            return None
+    def decode_boundary(value) -> np.ndarray:
         pbc = np.array([x == "periodic".encode() for x in value]).astype(bool)
         return pbc
 

--- a/znh5md/format/__init__.py
+++ b/znh5md/format/__init__.py
@@ -27,6 +27,7 @@ class GRP:
     stress: str = "stress"
     velocity: str = "velocity"
     pbc: str = "pbc"
+    dimension: str = "dimension"
 
     @staticmethod
     def encode_boundary(value) -> np.ndarray:

--- a/znh5md/format/__init__.py
+++ b/znh5md/format/__init__.py
@@ -3,6 +3,7 @@ import dataclasses
 import typing
 
 import h5py
+import numpy as np
 
 
 @dataclasses.dataclass
@@ -26,6 +27,19 @@ class GRP:
     stress: str = "stress"
     velocity: str = "velocity"
     pbc: str = "pbc"
+
+    @staticmethod
+    def encode_pbc(value) -> np.ndarray:
+        if value is None:  # TODO is this really required?
+            return None
+        return np.array(["periodic".encode() if x else "none".encode() for x in value])
+
+    @staticmethod
+    def decode_pbc(value) -> np.ndarray:  # TODO rename decode_boundary
+        if value is None:  # TODO is this really required?
+            return None
+        pbc = np.array([x == "periodic".encode() for x in value]).astype(bool)
+        return pbc
 
 
 @dataclasses.dataclass

--- a/znh5md/io/base.py
+++ b/znh5md/io/base.py
@@ -174,7 +174,7 @@ class DataWriter:
 
         Some groups, especially the box group, are nested differently.
         """
-        if groupname in ["edges", "pbc"]:
+        if groupname in [GRP.boundary, GRP.edges, GRP.pbc]:
             return f"box/{groupname}"
 
         return groupname

--- a/znh5md/io/base.py
+++ b/znh5md/io/base.py
@@ -192,15 +192,13 @@ class DataWriter:
         kwargs: dict[str, ExplicitStepTimeChunk]
             The chunk data to write to the database. The key is the name of the group.
         """
-        for group_name, chunk_data in kwargs.items():
-            log.debug(f"creating particle groups {group_name}")
-            with h5py.File(self.filename, "r+") as file:  # TODO opening the file is slow
+        with h5py.File(self.filename, "r+") as file:
+            for group_name, chunk_data in kwargs.items():
+                log.debug(f"creating particle groups {group_name}")
                 atoms = file[self.atoms_path]
                 if group_name == GRP.boundary:
                     # we create the box group
-                    atoms.create_dataset(
-                        f"box/{GRP.boundary}", data=chunk_data.value
-                    )
+                    atoms.create_dataset(f"box/{GRP.boundary}", data=chunk_data.value)
                     # TODO add dimension
                     continue
                 group_name = self._handle_special_cases_group_names(group_name)
@@ -221,8 +219,8 @@ class DataWriter:
             The chunk data to write to the database. The key is the name of the group.
             The group must already exist.
         """
-        for group_name, chunk_data in kwargs.items():
-            with h5py.File(self.filename, "r+") as file:  # TODO opening the file is slow
+        with h5py.File(self.filename, "r+") as file:
+            for group_name, chunk_data in kwargs.items():
                 if group_name == GRP.boundary:
                     if group_name not in file[f"{self.atoms_path}/box"]:
                         raise KeyError(f"Group {group_name} does not exist.")

--- a/znh5md/io/base.py
+++ b/znh5md/io/base.py
@@ -9,6 +9,8 @@ import numpy as np
 
 log = logging.getLogger(__name__)
 
+from znh5md.format import GRP
+
 
 @dataclasses.dataclass
 class StepTimeChunk:
@@ -172,7 +174,7 @@ class DataWriter:
 
         Some groups, especially the box group, are nested differently.
         """
-        if groupname in ["boundary", "edges", "pbc"]:
+        if groupname in ["edges", "pbc"]:
             return f"box/{groupname}"
 
         return groupname
@@ -192,8 +194,15 @@ class DataWriter:
         """
         for group_name, chunk_data in kwargs.items():
             log.debug(f"creating particle groups {group_name}")
-            with h5py.File(self.filename, "r+") as file:
+            with h5py.File(self.filename, "r+") as file:  # TODO opening the file is slow
                 atoms = file[self.atoms_path]
+                if group_name == GRP.boundary:
+                    # we create the box group
+                    atoms.create_dataset(
+                        f"box/{GRP.boundary}", data=chunk_data.value
+                    )
+                    # TODO add dimension
+                    continue
                 group_name = self._handle_special_cases_group_names(group_name)
                 dataset_group = atoms.create_group(group_name)
                 chunk_data.create_dataset(dataset_group)
@@ -213,7 +222,11 @@ class DataWriter:
             The group must already exist.
         """
         for group_name, chunk_data in kwargs.items():
-            with h5py.File(self.filename, "r+") as file:
+            with h5py.File(self.filename, "r+") as file:  # TODO opening the file is slow
+                if group_name == GRP.boundary:
+                    if group_name not in file[f"{self.atoms_path}/box"]:
+                        raise KeyError(f"Group {group_name} does not exist.")
+                    continue
                 atoms = file[self.atoms_path]
                 group_name = self._handle_special_cases_group_names(group_name)
                 dataset_group = atoms[group_name]

--- a/znh5md/io/base.py
+++ b/znh5md/io/base.py
@@ -199,7 +199,10 @@ class DataWriter:
                 if group_name == GRP.boundary:
                     # we create the box group
                     atoms.create_dataset(f"box/{GRP.boundary}", data=chunk_data.value)
-                    # TODO add dimension
+                    # dimension group is required by H5MD
+                    atoms.create_dataset(
+                        f"box/{GRP.dimension}", data=len(chunk_data.value)
+                    )
                     continue
                 group_name = self._handle_special_cases_group_names(group_name)
                 dataset_group = atoms.create_group(group_name)

--- a/znh5md/io/base.py
+++ b/znh5md/io/base.py
@@ -172,7 +172,7 @@ class DataWriter:
 
         Some groups, especially the box group, are nested differently.
         """
-        if groupname in ["boundary", "edges"]:
+        if groupname in ["boundary", "edges", "pbc"]:
             return f"box/{groupname}"
 
         return groupname

--- a/znh5md/io/reader.py
+++ b/znh5md/io/reader.py
@@ -166,6 +166,7 @@ class ASEFileReader(DataReader):
     frames_per_chunk: int = 5000
     time: float = 1
     step: int = 1
+    use_pbc_group: bool = False
 
     def yield_chunks(self) -> typing.Iterator[typing.Dict[str, FixedStepTimeChunk]]:
         """Yield chunks using AtomsReader."""
@@ -175,6 +176,7 @@ class ASEFileReader(DataReader):
             frames_per_chunk=self.frames_per_chunk,
             time=self.time,
             step=self.step,
+            use_pbc_group=self.use_pbc_group,
         )
 
         for atoms in tqdm.tqdm(ase.io.iread(self.filename)):

--- a/znh5md/io/reader.py
+++ b/znh5md/io/reader.py
@@ -40,13 +40,6 @@ class AtomsReader(DataReader):
     time: float = 1
     use_pbc_group: bool = False
 
-    def __post_init__(self):
-        if self.use_pbc_group:
-            log.warning(
-                "Using the 'pbc' group is not part of H5MD. This might cause issues with"
-                " other software."
-            )
-
     def _fill_with_nan(self, data: list) -> np.ndarray:
         max_n_particles = max(x.shape[0] for x in data)
         dimensions = data[0].shape[1:]
@@ -91,9 +84,8 @@ class AtomsReader(DataReader):
         return np.array([[x.get_pbc()] for x in atoms]).astype(bool)
 
     def _get_boundary(self, atoms: list[ase.Atoms]) -> np.ndarray:
-        data = atoms[
-            0
-        ].get_pbc()  # boundary is constant and should be the same for all atoms
+        data = atoms[0].get_pbc()
+        # boundary is constant and should be the same for all atoms
         return GRP.encode_boundary(data)
 
     def yield_chunks(

--- a/znh5md/io/reader.py
+++ b/znh5md/io/reader.py
@@ -71,7 +71,7 @@ class AtomsReader(DataReader):
     def _get_edges(self, atoms: list[ase.Atoms]) -> np.ndarray:
         return np.array([x.get_cell() for x in atoms]).astype(float)
 
-    def _get_boundary(self, atoms: list[ase.Atoms]) -> np.ndarray:
+    def _get_pbc(self, atoms: list[ase.Atoms]) -> np.ndarray:
         return np.array([[x.get_pbc()] for x in atoms]).astype(bool)
 
     def yield_chunks(
@@ -95,7 +95,7 @@ class AtomsReader(DataReader):
                 GRP.forces: self._get_forces,
                 GRP.stress: self._get_stress,
                 GRP.edges: self._get_edges,
-                GRP.boundary: self._get_boundary,
+                GRP.pbc: self._get_pbc,
             }
 
             for name in group_names or functions:

--- a/znh5md/io/reader.py
+++ b/znh5md/io/reader.py
@@ -94,7 +94,7 @@ class AtomsReader(DataReader):
         data = atoms[
             0
         ].get_pbc()  # boundary is constant and should be the same for all atoms
-        return GRP.encode_pbc(data)
+        return GRP.encode_boundary(data)
 
     def yield_chunks(
         self, group_names: list = None

--- a/znh5md/znh5md/__init__.py
+++ b/znh5md/znh5md/__init__.py
@@ -192,7 +192,7 @@ class ASEH5MD(H5MDBase):
             GRP.position,
             GRP.velocity,
             GRP.edges,
-            GRP.boundary,
+            GRP.pbc,
             GRP.energy,
             GRP.forces,
             GRP.stress,
@@ -211,7 +211,7 @@ class ASEH5MD(H5MDBase):
                     rm_nan(data[GRP.velocity][idx]) if GRP.velocity in data else None
                 ),
                 cell=data[GRP.edges][idx] if GRP.edges in data else None,
-                pbc=(data[GRP.boundary][idx] if GRP.boundary in data else None),
+                pbc=(data[GRP.pbc][idx] if GRP.pbc in data else None),
             )
             if GRP.forces in data or GRP.energy in data or GRP.stress in data:
                 obj.calc = SinglePointCalculator(

--- a/znh5md/znh5md/__init__.py
+++ b/znh5md/znh5md/__init__.py
@@ -219,7 +219,7 @@ class ASEH5MD(H5MDBase):
                 ),
                 cell=data[GRP.edges][idx] if GRP.edges in data else None,
                 pbc=(
-                    GRP.decode_pbc(data[GRP.boundary]) if GRP.boundary in data else None
+                    GRP.decode_boundary(data[GRP.boundary]) if GRP.boundary in data else None
                 ),
             )
             if GRP.forces in data or GRP.energy in data or GRP.stress in data:

--- a/znh5md/znh5md/__init__.py
+++ b/znh5md/znh5md/__init__.py
@@ -219,7 +219,9 @@ class ASEH5MD(H5MDBase):
                 ),
                 cell=data[GRP.edges][idx] if GRP.edges in data else None,
                 pbc=(
-                    GRP.decode_boundary(data[GRP.boundary]) if GRP.boundary in data else None
+                    GRP.decode_boundary(data[GRP.boundary])
+                    if GRP.boundary in data
+                    else None
                 ),
             )
             if GRP.forces in data or GRP.energy in data or GRP.stress in data:


### PR DESCRIPTION
The H5MD boundary group is fixed in time. The optional pbc group is not and allows to also store configurations that don't share 
the same periodic boundary conditions.

This also fixed how `boundary` are stored.