### PR TITLE
Support-arrays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "znh5md"
-version = "0.1.8"
+version = "0.1.9"
 description = "High Performance Interface for H5MD Trajectories"
 authors = ["zincwarecode <zincwarecode@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,3 +95,14 @@ def atoms_list(request) -> list[ase.Atoms]:
         atom.calc.results["predicted_energy"] = idx / 21 + 0.5
 
     return atoms
+
+@pytest.fixture
+def atoms_list_with_custom_arrays():
+    atoms = [ase.build.molecule(x) for x in ase.collections.g2.names]
+    for atom in atoms:
+        atom.set_velocities(np.random.rand(len(atom), 3))
+        atom.arrays['forces_1'] = np.random.rand(len(atom), 3) # e.g. forces
+        atom.arrays['stress_1'] = np.random.rand(3, 3) # e.g. stress
+        atom.arrays['energy_1'] = np.random.rand() # e.g. energy
+
+    return atoms

--- a/tests/test_znh5md.py
+++ b/tests/test_znh5md.py
@@ -5,7 +5,7 @@ import znh5md
 
 
 def test_version():
-    assert znh5md.__version__ == "0.1.8"
+    assert znh5md.__version__ == "0.1.9"
 
 
 def test_shape(example_h5):

--- a/znh5md/io/reader.py
+++ b/znh5md/io/reader.py
@@ -140,7 +140,7 @@ class AtomsReader(DataReader):
                 # We assume they occur in all the others as well.
                 for key in self.atoms[0].calc.results:
                     if key not in functions:
-                        value = [x.calc.results[key] for x in self.atoms]
+                        value = [x.calc.results[key] for x in self.atoms[start_index:stop_index]]
                         try:
                             value = np.array(value).astype(float)
                         except ValueError:

--- a/znh5md/utils.py
+++ b/znh5md/utils.py
@@ -7,3 +7,6 @@ def rm_nan(x):
     if len(x.shape) == 1:
         return x[~np.isnan(x)]
     return x[~np.isnan(x).any(axis=1)]
+
+# Keys that we ignore when reading ASE arrays
+ASE_ARRAYS_KEYS = ["numbers", "positions", "tags", "momenta", "masses", "initial_magmoms", "initial_charges"]

--- a/znh5md/znh5md/h5ase.py
+++ b/znh5md/znh5md/h5ase.py
@@ -6,6 +6,7 @@ import ase
 import h5py
 import numpy as np
 from ase.calculators.singlepoint import SinglePointCalculator
+from ase.calculators.calculator import all_properties
 
 from znh5md.format import GRP, OBSERVABLES_GRP, PARTICLES_GRP
 from znh5md.utils import rm_nan
@@ -118,7 +119,10 @@ class ASEH5MD(H5MDBase):
                     obj, forces=_gather_value(particles_data, GRP.forces, idx)
                 )
                 for key in observables_data:
-                    obj.calc.results[key] = observables_data[key][idx]
+                    if key in all_properties:
+                        obj.calc.results[key] = observables_data[key][idx]
+                    else:
+                        obj.arrays[key] = rm_nan(observables_data[key][idx])
 
             atoms.append(obj)
 


### PR DESCRIPTION
Partially add support for `atoms.arrays`
- missing "tags", "masses", "initial_magmoms", "initial_charges"

Error message to fix (also happens on main)

```
Traceback (most recent call last):
  File "/ssd/fzills/IPS/BMIM_BF4/combine_to_one.py", line 18, in <module>
    db.add(znh5md.io.AtomsReader(atoms))
  File "/data/fzills/miniconda3/envs/ipsuite/lib/python3.10/site-packages/znh5md/io/base.py", line 272, in add
    for chunk in reader.yield_chunks():
  File "/data/fzills/miniconda3/envs/ipsuite/lib/python3.10/site-packages/znh5md/io/reader.py", line 169, in yield_chunks
    value = [x.calc.results[key] for x in self.atoms[start_index:stop_index]]
  File "/data/fzills/miniconda3/envs/ipsuite/lib/python3.10/site-packages/znh5md/io/reader.py", line 169, in <listcomp>
    value = [x.calc.results[key] for x in self.atoms[start_index:stop_index]]
AttributeError: 'NoneType' object has no attribute 'results'
```