### PR TITLE
Add ASE plugin support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,6 @@ skip = "poetry.lock,*.ipynb"
 
 [tool.pytest.ini_options]
 addopts = "-m 'not benchmark'"
+
+[tool.poetry.plugins."ase.ioformats"]
+znh5md = "znh5md.ase_plugin:znh5md_format"

--- a/tests/test_ase_plugin.py
+++ b/tests/test_ase_plugin.py
@@ -1,0 +1,72 @@
+from ase.atoms import Atoms
+from ase.collections import s22
+from ase.io import read, write
+
+import znh5md
+
+
+def test_write_one(tmp_path):
+    path = tmp_path / "test.h5"
+
+    atoms = list(s22)[0]
+    write(path, atoms)
+
+    io = znh5md.IO(path)
+    images_read = io[:]
+
+    assert len(images_read) == 1
+    assert atoms == images_read[0]
+
+
+def test_write_multiple(tmp_path):
+    path = tmp_path / "test.h5"
+
+    images = list(s22)
+    write(path, images)
+
+    io = znh5md.IO(path)
+    images_read = io[:]
+
+    assert len(images) == len(images_read)
+    for image, image_read in zip(images, images_read):
+        assert image == image_read
+
+
+def test_append(tmp_path):
+    path = tmp_path / "test.h5"
+
+    images = list(s22)
+    for image in images:
+        write(path, image, append=True)
+
+    io = znh5md.IO(path)
+    images_read = io[:]
+
+    assert len(images) == len(images_read)
+    for image, image_read in zip(images, images_read):
+        assert image == image_read
+
+
+def test_read_one(tmp_path):
+    path = tmp_path / "test.h5"
+    io = znh5md.IO(path)
+
+    images = list(s22)
+    io.extend(images)
+
+    image_read = read(path, index=0)
+    assert isinstance(image_read, Atoms)
+    assert images[0] == image_read
+
+
+def test_read_multiple(tmp_path):
+    path = tmp_path / "test.h5"
+    io = znh5md.IO(path)
+
+    images = list(s22)
+    io.extend(images)
+
+    images_read = read(path, index=':')
+    assert isinstance(images_read, list)
+    for image, image_read in zip(images, images_read):
+        assert image == image_read

--- a/tests/test_ase_plugin.py
+++ b/tests/test_ase_plugin.py
@@ -66,7 +66,7 @@ def test_read_multiple(tmp_path):
     images = list(s22)
     io.extend(images)
 
-    images_read = read(path, index=':')
+    images_read = read(path, index=":")
     assert isinstance(images_read, list)
     for image, image_read in zip(images, images_read):
         assert image == image_read

--- a/znh5md/ase_plugin.py
+++ b/znh5md/ase_plugin.py
@@ -7,10 +7,10 @@ from ase.utils.plugins import ExternalIOFormat
 from znh5md.io import IO
 
 znh5md_format = ExternalIOFormat(
-    desc='ZnH5MD h5 file',
-    code='+S',  # multiple atoms objects, accepts a file name string
-    module='znh5md.ase_plugin',
-    ext='h5'
+    desc="ZnH5MD h5 file",
+    code="+S",  # multiple atoms objects, accepts a file name string
+    module="znh5md.ase_plugin",
+    ext="h5",
 )
 
 

--- a/znh5md/ase_plugin.py
+++ b/znh5md/ase_plugin.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import Generator
+
+from ase.atoms import Atoms
+from ase.utils.plugins import ExternalIOFormat
+
+from znh5md.io import IO
+
+znh5md_format = ExternalIOFormat(
+    desc='ZnH5MD h5 file',
+    code='+S',  # multiple atoms objects, accepts a file name string
+    module='znh5md.ase_plugin',
+    ext='h5'
+)
+
+
+def read_znh5md(filename: str, index: slice) -> Generator[Atoms, None, None]:
+    yield from IO(filename=filename, tqdm_limit=0)[index]
+
+
+def write_znh5md(filename: str, images: list[Atoms], append: bool = False):
+    if not append and Path(filename).exists():
+        Path(filename).unlink()
+    IO(filename=filename, tqdm_limit=0).extend(images)


### PR DESCRIPTION
This PR adds ASE plugin support, so that `ase.io.read` and `ase.io.write` can also operate on ZnH5MD files. Probably most useful in a visualization context, as `ase gui atoms.h5` also works.

Note that there are some performance issues in ASE regarding reading a single index from a large file which currently affect for instance `ase.io.read('atoms.h5', index=0)` but not `znh5md.IO('atoms.h5')[0]`. See [the related issue on ASE's repository](https://gitlab.com/ase/ase/-/issues/1577) for more details.