### PR TITLE
Add timestep export functionality

### DIFF
--- a/tests/test_timestep.py
+++ b/tests/test_timestep.py
@@ -6,23 +6,33 @@ import pytest
 
 import znh5md
 
+
 @pytest.fixture
 def trajectory_time(tmp_path):
     """Fixture to create a trajectory with time information."""
-    io = znh5md.IO(tmp_path / "test_time_step.h5", store="time", export_timestep=True, timestep=0.5)
+    io = znh5md.IO(
+        tmp_path / "test_time_step.h5", store="time", export_timestep=True, timestep=0.5
+    )
     for _ in range(1, 10):
         atoms = ase.build.molecule("H2O")
         io.append(atoms)
     return io
 
+
 @pytest.fixture
 def trajectory_linear(tmp_path):
     """Fixture to create a trajectory with linear storage."""
-    io = znh5md.IO(tmp_path / "test_linear_step.h5", store="linear", export_timestep=True, timestep=0.5)
+    io = znh5md.IO(
+        tmp_path / "test_linear_step.h5",
+        store="linear",
+        export_timestep=True,
+        timestep=0.5,
+    )
     for _ in range(1, 10):
         atoms = ase.build.molecule("H2O")
         io.append(atoms)
     return io
+
 
 @pytest.mark.parametrize("trajectory", ["trajectory_time", "trajectory_linear"])
 def test_time_step(trajectory, request):

--- a/tests/test_timestep.py
+++ b/tests/test_timestep.py
@@ -1,8 +1,51 @@
 import warnings
 
 import ase.build
+import numpy as np
+import pytest
 
 import znh5md
+
+@pytest.fixture
+def trajectory_time(tmp_path):
+    """Fixture to create a trajectory with time information."""
+    io = znh5md.IO(tmp_path / "test_time_step.h5", store="time", export_timestep=True, timestep=0.5)
+    for _ in range(1, 10):
+        atoms = ase.build.molecule("H2O")
+        io.append(atoms)
+    return io
+
+@pytest.fixture
+def trajectory_linear(tmp_path):
+    """Fixture to create a trajectory with linear storage."""
+    io = znh5md.IO(tmp_path / "test_linear_step.h5", store="linear", export_timestep=True, timestep=0.5)
+    for _ in range(1, 10):
+        atoms = ase.build.molecule("H2O")
+        io.append(atoms)
+    return io
+
+@pytest.mark.parametrize("trajectory", ["trajectory_time", "trajectory_linear"])
+def test_time_step(trajectory, request):
+    """Test that the time step is correctly stored and retrieved."""
+    io = request.getfixturevalue(trajectory)
+
+    assert io[0].info["timestep"] == 0
+    assert io[1].info["timestep"] == 0.5
+
+    timesteps = [atoms.info["timestep"] for atoms in io[:]]
+    assert timesteps == list(np.arange(0, 9) * 0.5)
+
+    timesteps = [atoms.info["timestep"] for atoms in io[::2]]
+    assert timesteps == list(np.arange(0, 9) * 0.5)[::2]
+
+    timesteps = [atoms.info["timestep"] for atoms in io[1:3]]
+    assert timesteps == [0.5, 1.0]
+
+    timesteps = [atoms.info["timestep"] for atoms in io[[2, 6, 7]]]
+    assert timesteps == list(np.arange(0, 9)[[2, 6, 7]] * 0.5)
+
+    assert io.timestep == 0.5
+
 
 # def test_h5md_time(tmp_path):
 #     io = znh5md.IO(tmp_path / "test_time_step.h5", store="time")

--- a/uv.lock
+++ b/uv.lock
@@ -1961,7 +1961,7 @@ wheels = [
 
 [[package]]
 name = "znh5md"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "ase" },

--- a/znh5md/interface/io.py
+++ b/znh5md/interface/io.py
@@ -216,7 +216,7 @@ class IO(MutableSequence):
             ) as f:
                 if self.particles_group and f"particles/{self.particles_group}" in f:
                     particles = f[f"particles/{self.particles_group}"]
-                    
+
                     # Read timestep from the species group (always present)
                     if "species" in particles and "time" in particles["species"]:
                         time_data = particles["species"]["time"]

--- a/znh5md/interface/io.py
+++ b/znh5md/interface/io.py
@@ -86,6 +86,10 @@ class IO(MutableSequence):
     mask : list[int] | slice | None, optional
         Mask to apply when reading data, e.g., to select specific atoms.
         Not supported with `variable_shape=True`. Defaults to None.
+    export_timestep : bool, optional
+        Whether to save the timestep into the atoms.info object when reading.
+        The timestep represents the step of the atoms object in femtoseconds from the start.
+        Defaults to False.
 
     Raises
     ------
@@ -142,6 +146,7 @@ class IO(MutableSequence):
     variable_shape: bool = True
     include: list[str] | None = None
     mask: list[int] | slice | None = None
+    export_timestep: bool = False
 
     _store_ase_origin: bool = True  # for testing purposes only
 
@@ -163,6 +168,7 @@ class IO(MutableSequence):
             self.filename = pathlib.Path(self.filename)
         self._set_particle_group()
         self._read_author_creator()
+        self._read_timestep()
         if self.include is not None:
             if "position" not in self.include:
                 raise ValueError("'position' must be in keys")
@@ -201,6 +207,23 @@ class IO(MutableSequence):
                 self.author_email = f["h5md"]["author"].attrs["email"]
                 self.creator = f["h5md"]["creator"].attrs["name"]
                 self.creator_version = f["h5md"]["creator"].attrs["version"]
+
+    def _read_timestep(self):
+        """Read timestep from h5 file if available as a single scalar value."""
+        with contextlib.suppress(FileNotFoundError, KeyError, OSError):
+            with open_file(
+                self.filename, self.file_handle, self.file_factory, mode="r"
+            ) as f:
+                if self.particles_group and f"particles/{self.particles_group}" in f:
+                    particles = f[f"particles/{self.particles_group}"]
+                    
+                    # Read timestep from the species group (always present)
+                    if "species" in particles and "time" in particles["species"]:
+                        time_data = particles["species"]["time"]
+                        # Only use if it's a single scalar value (linear storage mode)
+                        if time_data.shape == ():
+                            self.timestep = float(time_data[()])
+                            return
 
     def create_file(self):
         with open_file(

--- a/znh5md/interface/read.py
+++ b/znh5md/interface/read.py
@@ -217,6 +217,11 @@ def getitem(
         if f"/observables/{self.particles_group}" in f:
             observables = f[f"/observables/{self.particles_group}"]
             process_observables(self, frames, observables, index)
+        
+        # Add timestep information if export_timestep is True
+        if self.export_timestep:
+            add_timestep_info(self, frames, particles, index)
+    
     return list(frames) if not is_single_item else frames[0]
 
 
@@ -420,3 +425,62 @@ def process_observables(self: "IO", frames: Frames, observables, index) -> None:
             )
         except Exception as err:
             raise ValueError(f"Error processing group '{grp_name}'") from err
+
+
+def add_timestep_info(self: "IO", frames: Frames, particles, index) -> None:
+    """
+    Add timestep information to atoms.info when export_timestep is True.
+    
+    Parameters
+    ----------
+    self : IO
+        The IO object containing file information and settings.
+    frames : Frames
+        The frames to update with timestep information.
+    particles : h5py.Group
+        The particles group from the HDF5 file.
+    index : int | slice | list[int] | np.ndarray
+        Indices specifying the frames to retrieve.
+    """
+    # Try to find timestep information from the species group (always present)
+    timestep_fs = None
+    
+    # Read timestep from the species group
+    if "species" in particles and "time" in particles["species"]:
+        time_data = particles["species"]["time"]
+        if time_data.shape == ():  # Single scalar value
+            # This is "linear" storage mode - time per step
+            timestep_fs = float(time_data[()])
+        elif len(time_data) > 1:
+            # This is "time" storage mode - array of times
+            # Calculate timestep from the difference
+            time_array = time_data[:]
+            timestep_fs = float(time_array[1] - time_array[0]) if len(time_array) > 1 else float(time_array[0])
+    
+    # If no timestep found, use the default from IO instance
+    if timestep_fs is None:
+        timestep_fs = self.timestep
+    
+    # Calculate timestep for each requested frame and add to frames.info
+    timestep_values = []
+    
+    # Get the total dataset length for slice conversion
+    total_length = len(particles["species"]["value"])
+    
+    # Handle different index types
+    if isinstance(index, slice):
+        # Convert slice to list of indices based on total dataset length
+        start, stop, step = index.indices(total_length)
+        actual_indices = list(range(start, stop, step))
+    elif isinstance(index, (list, np.ndarray)):
+        actual_indices = list(index)
+    else:
+        actual_indices = [index]
+    
+    for frame_idx in actual_indices:
+        # Calculate the timestep for this specific frame (in femtoseconds from start)
+        frame_timestep = frame_idx * timestep_fs
+        timestep_values.append(frame_timestep)
+    
+    # Add timestep to frames.info dictionary
+    frames.info['timestep'] = timestep_values

--- a/znh5md/interface/read.py
+++ b/znh5md/interface/read.py
@@ -217,11 +217,11 @@ def getitem(
         if f"/observables/{self.particles_group}" in f:
             observables = f[f"/observables/{self.particles_group}"]
             process_observables(self, frames, observables, index)
-        
+
         # Add timestep information if export_timestep is True
         if self.export_timestep:
             add_timestep_info(self, frames, particles, index)
-    
+
     return list(frames) if not is_single_item else frames[0]
 
 
@@ -430,7 +430,7 @@ def process_observables(self: "IO", frames: Frames, observables, index) -> None:
 def add_timestep_info(self: "IO", frames: Frames, particles, index) -> None:
     """
     Add timestep information to atoms.info when export_timestep is True.
-    
+
     Parameters
     ----------
     self : IO
@@ -444,7 +444,7 @@ def add_timestep_info(self: "IO", frames: Frames, particles, index) -> None:
     """
     # Try to find timestep information from the species group (always present)
     timestep_fs = None
-    
+
     # Read timestep from the species group
     if "species" in particles and "time" in particles["species"]:
         time_data = particles["species"]["time"]
@@ -455,18 +455,22 @@ def add_timestep_info(self: "IO", frames: Frames, particles, index) -> None:
             # This is "time" storage mode - array of times
             # Calculate timestep from the difference
             time_array = time_data[:]
-            timestep_fs = float(time_array[1] - time_array[0]) if len(time_array) > 1 else float(time_array[0])
-    
+            timestep_fs = (
+                float(time_array[1] - time_array[0])
+                if len(time_array) > 1
+                else float(time_array[0])
+            )
+
     # If no timestep found, use the default from IO instance
     if timestep_fs is None:
         timestep_fs = self.timestep
-    
+
     # Calculate timestep for each requested frame and add to frames.info
     timestep_values = []
-    
+
     # Get the total dataset length for slice conversion
     total_length = len(particles["species"]["value"])
-    
+
     # Handle different index types
     if isinstance(index, slice):
         # Convert slice to list of indices based on total dataset length
@@ -476,11 +480,11 @@ def add_timestep_info(self: "IO", frames: Frames, particles, index) -> None:
         actual_indices = list(index)
     else:
         actual_indices = [index]
-    
+
     for frame_idx in actual_indices:
         # Calculate the timestep for this specific frame (in femtoseconds from start)
         frame_timestep = frame_idx * timestep_fs
         timestep_values.append(frame_timestep)
-    
+
     # Add timestep to frames.info dictionary
-    frames.info['timestep'] = timestep_values
+    frames.info["timestep"] = timestep_values


### PR DESCRIPTION
- Add export_timestep parameter to IO class to enable timestep information in atoms.info
- Implement timestep reading from HDF5 files supporting both time and linear storage modes
- Add comprehensive tests for timestep functionality with parameterized fixtures
- Update version to 0.4.9 in uv.lock

- [ ] test if `timestep` is in atoms.info object
- [ ] test if export is set to false